### PR TITLE
fix: validate negative TAO amounts in staking

### DIFF
--- a/bittensor-rs/src/extrinsics/staking.rs
+++ b/bittensor-rs/src/extrinsics/staking.rs
@@ -29,6 +29,8 @@ pub struct StakeParams {
 impl StakeParams {
     /// Create new stake params with amount in TAO
     ///
+    /// Returns an error if the amount is negative.
+    ///
     /// # Example
     ///
     /// ```
@@ -38,15 +40,21 @@ impl StakeParams {
     ///     "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
     ///     1,   // netuid
     ///     1.5  // TAO
-    /// );
+    /// ).unwrap();
     /// assert_eq!(params.amount_rao, 1_500_000_000);
     /// ```
-    pub fn new_tao(hotkey: &str, netuid: u16, amount_tao: f64) -> Self {
-        Self {
+    pub fn new_tao(hotkey: &str, netuid: u16, amount_tao: f64) -> Result<Self, BittensorError> {
+        if amount_tao < 0.0 {
+            return Err(BittensorError::ConfigError {
+                field: "amount_tao".to_string(),
+                message: format!("Stake amount cannot be negative: {}", amount_tao),
+            });
+        }
+        Ok(Self {
             hotkey: hotkey.to_string(),
             netuid,
             amount_rao: (amount_tao * 1_000_000_000.0) as u64,
-        }
+        })
     }
 
     /// Create new stake params with amount in RAO
@@ -74,21 +82,21 @@ impl StakeParams {
 /// An `ExtrinsicResponse` with the staking result
 ///
 /// # Example
-///
-/// ```rust,ignore
-/// use bittensor_rs::extrinsics::{add_stake, StakeParams};
-///
-/// async fn example(client: &subxt::OnlineClient<subxt::PolkadotConfig>, signer: &impl subxt::tx::Signer<subxt::PolkadotConfig>) -> Result<(), Box<dyn std::error::Error>> {
-///     let params = StakeParams::new_tao(
-///         "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-///         1,    // netuid
-///         1.0   // TAO amount
-///     );
-///     let result = add_stake(client, signer, params).await?;
-///     Ok(())
-/// }
-/// ```
-pub async fn add_stake<S>(
+    ///
+    /// ```rust,ignore
+    /// use bittensor_rs::extrinsics::{add_stake, StakeParams};
+    ///
+    /// async fn example(client: &subxt::OnlineClient<subxt::PolkadotConfig>, signer: &impl subxt::tx::Signer<subxt::PolkadotConfig>) -> Result<(), Box<dyn std::error::Error>> {
+    ///     let params = StakeParams::new_tao(
+    ///         "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    ///         1,    // netuid
+    ///         1.0   // TAO amount
+    ///     )?;
+    ///     let result = add_stake(client, signer, params).await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn add_stake<S>(
     client: &OnlineClient<PolkadotConfig>,
     signer: &S,
     params: StakeParams,
@@ -222,9 +230,29 @@ mod tests {
     #[test]
     fn test_stake_params_tao() {
         let params =
-            StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, 1.5);
+            StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, 1.5)
+                .unwrap();
         assert_eq!(params.amount_rao, 1_500_000_000);
         assert_eq!(params.netuid, 1);
+    }
+
+    #[test]
+    fn test_stake_params_tao_zero_amount() {
+        // Zero amount should be allowed (no-op stake)
+        let params =
+            StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, 0.0)
+                .unwrap();
+        assert_eq!(params.amount_rao, 0);
+    }
+
+    #[test]
+    fn test_stake_params_tao_negative_amount_rejected() {
+        // Negative amounts should be rejected to prevent u64 overflow
+        let result =
+            StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, -1.0);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("cannot be negative"));
     }
 
     #[test]


### PR DESCRIPTION
**Problem**
`StakeParams::new_tao()` accepted negative TAO amounts without validation. When a negative f64 is cast to u64, it produces a massive value (close to u64::MAX), causing incorrect staking amounts.

**Solution**
- Add validation to reject negative amounts in `new_tao()`
- Return `Result<Self, BittensorError>` for proper error handling
- Added tests for negative amount rejection and zero amount handling

**Changes**
- `bittensor-rs/src/extrinsics/staking.rs`: 48 insertions, 20 deletions

This prevents users from accidentally staking massive amounts when passing negative values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Staking operations now include enhanced input validation to prevent processing of negative amounts, providing clear error messages for invalid inputs.

* **Tests**
  * Added comprehensive test coverage for edge cases, including zero amounts and negative amount rejection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->