### PR TITLE
fix: reject negative TAO amounts in staking and transfer params

### DIFF
--- a/bittensor-rs/src/error.rs
+++ b/bittensor-rs/src/error.rs
@@ -148,6 +148,9 @@ pub enum BittensorError {
 
     #[error("Insufficient balance: {available} < {required}")]
     InsufficientBalance { available: u64, required: u64 },
+
+    #[error("Invalid amount: {reason}")]
+    InvalidAmount { reason: String },
 }
 
 /// Classification of errors for retry logic
@@ -443,7 +446,8 @@ impl BittensorError {
             | BittensorError::MaxRetriesExceeded { .. }
             | BittensorError::BackoffTimeoutReached { .. }
             | BittensorError::BlockNotFound { .. }
-            | BittensorError::InvalidBlockNumber { .. } => ErrorCategory::Permanent,
+            | BittensorError::InvalidBlockNumber { .. }
+            | BittensorError::InvalidAmount { .. } => ErrorCategory::Permanent,
 
             // Legacy errors - categorize based on content
             BittensorError::RpcError { message }

--- a/bittensor-rs/src/extrinsics/staking.rs
+++ b/bittensor-rs/src/extrinsics/staking.rs
@@ -38,15 +38,20 @@ impl StakeParams {
     ///     "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
     ///     1,   // netuid
     ///     1.5  // TAO
-    /// );
+    /// ).unwrap();
     /// assert_eq!(params.amount_rao, 1_500_000_000);
     /// ```
-    pub fn new_tao(hotkey: &str, netuid: u16, amount_tao: f64) -> Self {
-        Self {
+    pub fn new_tao(hotkey: &str, netuid: u16, amount_tao: f64) -> Result<Self, BittensorError> {
+        if amount_tao < 0.0 {
+            return Err(BittensorError::InvalidAmount {
+                reason: format!("TAO amount must be non-negative, got {}", amount_tao),
+            });
+        }
+        Ok(Self {
             hotkey: hotkey.to_string(),
             netuid,
             amount_rao: (amount_tao * 1_000_000_000.0) as u64,
-        }
+        })
     }
 
     /// Create new stake params with amount in RAO
@@ -83,7 +88,7 @@ impl StakeParams {
 ///         "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
 ///         1,    // netuid
 ///         1.0   // TAO amount
-///     );
+///     )?;
 ///     let result = add_stake(client, signer, params).await?;
 ///     Ok(())
 /// }
@@ -222,9 +227,17 @@ mod tests {
     #[test]
     fn test_stake_params_tao() {
         let params =
-            StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, 1.5);
+            StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, 1.5)
+                .unwrap();
         assert_eq!(params.amount_rao, 1_500_000_000);
         assert_eq!(params.netuid, 1);
+    }
+
+    #[test]
+    fn test_stake_params_negative_tao() {
+        let result =
+            StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, -1.0);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/bittensor-rs/src/extrinsics/staking.rs
+++ b/bittensor-rs/src/extrinsics/staking.rs
@@ -42,9 +42,9 @@ impl StakeParams {
     /// assert_eq!(params.amount_rao, 1_500_000_000);
     /// ```
     pub fn new_tao(hotkey: &str, netuid: u16, amount_tao: f64) -> Result<Self, BittensorError> {
-        if amount_tao < 0.0 {
+        if !amount_tao.is_finite() || amount_tao < 0.0 {
             return Err(BittensorError::InvalidAmount {
-                reason: format!("TAO amount must be non-negative, got {}", amount_tao),
+                reason: format!("TAO amount must be a non-negative finite number, got {}", amount_tao),
             });
         }
         Ok(Self {
@@ -237,6 +237,23 @@ mod tests {
     fn test_stake_params_negative_tao() {
         let result =
             StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, -1.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_stake_params_nan_tao() {
+        let result =
+            StakeParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1, f64::NAN);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_stake_params_infinity_tao() {
+        let result = StakeParams::new_tao(
+            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            1,
+            f64::INFINITY,
+        );
         assert!(result.is_err());
     }
 

--- a/bittensor-rs/src/extrinsics/transfer.rs
+++ b/bittensor-rs/src/extrinsics/transfer.rs
@@ -40,9 +40,9 @@ impl TransferParams {
     /// assert_eq!(params.amount_rao, 1_500_000_000);
     /// ```
     pub fn new_tao(dest: &str, amount_tao: f64) -> Result<Self, BittensorError> {
-        if amount_tao < 0.0 {
+        if !amount_tao.is_finite() || amount_tao < 0.0 {
             return Err(BittensorError::InvalidAmount {
-                reason: format!("TAO amount must be non-negative, got {}", amount_tao),
+                reason: format!("TAO amount must be a non-negative finite number, got {}", amount_tao),
             });
         }
         Ok(Self {
@@ -233,6 +233,22 @@ mod tests {
     fn test_transfer_params_negative_tao() {
         let result =
             TransferParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", -1.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transfer_params_nan_tao() {
+        let result =
+            TransferParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", f64::NAN);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transfer_params_infinity_tao() {
+        let result = TransferParams::new_tao(
+            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            f64::INFINITY,
+        );
         assert!(result.is_err());
     }
 

--- a/bittensor-rs/src/extrinsics/transfer.rs
+++ b/bittensor-rs/src/extrinsics/transfer.rs
@@ -36,15 +36,20 @@ impl TransferParams {
     /// let params = TransferParams::new_tao(
     ///     "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
     ///     1.5
-    /// );
+    /// ).unwrap();
     /// assert_eq!(params.amount_rao, 1_500_000_000);
     /// ```
-    pub fn new_tao(dest: &str, amount_tao: f64) -> Self {
-        Self {
+    pub fn new_tao(dest: &str, amount_tao: f64) -> Result<Self, BittensorError> {
+        if amount_tao < 0.0 {
+            return Err(BittensorError::InvalidAmount {
+                reason: format!("TAO amount must be non-negative, got {}", amount_tao),
+            });
+        }
+        Ok(Self {
             dest: dest.to_string(),
             amount_rao: (amount_tao * 1_000_000_000.0) as u64,
             keep_alive: true,
-        }
+        })
     }
 
     /// Create new transfer params with amount in RAO
@@ -84,7 +89,7 @@ impl TransferParams {
 ///     let params = TransferParams::new_tao(
 ///         "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
 ///         1.0
-///     );
+///     )?;
 ///     let result = transfer(client, signer, params).await?;
 ///     Ok(())
 /// }
@@ -218,9 +223,17 @@ mod tests {
     #[test]
     fn test_transfer_params_tao() {
         let params =
-            TransferParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1.5);
+            TransferParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1.5)
+                .unwrap();
         assert_eq!(params.amount_rao, 1_500_000_000);
         assert!(params.keep_alive);
+    }
+
+    #[test]
+    fn test_transfer_params_negative_tao() {
+        let result =
+            TransferParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", -1.0);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -234,6 +247,7 @@ mod tests {
     fn test_transfer_params_builder() {
         let params =
             TransferParams::new_tao("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1.0)
+                .unwrap()
                 .keep_alive(false);
 
         assert!(!params.keep_alive);


### PR DESCRIPTION
Fixes #8

Rejects negative TAO values early in `new_tao()` to prevent integer overflow in downstream staking and transfer operations.

Changes:
- `error.rs`: Added `InvalidAmount { reason: String }` error variant
- `staking.rs`: `new_tao()` now returns `Result<Self, BittensorError>` and rejects negative inputs
- `transfer.rs`: Same validation pattern

This is a minimal, focused fix that addresses the root cause without changing any business logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved input validation for TAO amounts (rejects negative, NaN, or infinite values).

* **Bug Fixes**
  * Invalid TAO values now produce clear, descriptive errors instead of creating invalid state.

* **Breaking Changes**
  * Amount constructors/builders now surface validation errors; call sites must handle potential error returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->