### PR TITLE
fix(codegen): support current Bittensor metadata

### DIFF
--- a/bittensor-rs/build.rs
+++ b/bittensor-rs/build.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use parity_scale_codec::Decode;
 use sha2::{Digest, Sha256};
-use subxt_codegen::CodegenBuilder;
+use subxt_codegen::{syn::parse_quote, CodegenBuilder};
 use subxt_metadata::Metadata;
 use subxt_utils_fetchmetadata::{from_url_blocking, MetadataVersion, Url};
 
@@ -125,8 +125,27 @@ fn generate_code(metadata_bytes: &[u8], code_path: &Path, hash_path: &Path) {
     // Decode metadata
     let metadata = Metadata::decode(&mut &metadata_bytes[..]).expect("Failed to decode metadata");
 
+    // Preserve the primitive client API for SCALE-compatible runtime newtypes.
+    let mut codegen = CodegenBuilder::new();
+    codegen.set_type_substitute(
+        parse_quote!(subtensor_runtime_common::NetUid),
+        parse_quote!(::core::primitive::u16),
+    );
+    codegen.set_type_substitute(
+        parse_quote!(subtensor_runtime_common::currency::TaoBalance),
+        parse_quote!(::core::primitive::u64),
+    );
+    codegen.set_type_substitute(
+        parse_quote!(subtensor_runtime_common::currency::AlphaBalance),
+        parse_quote!(::core::primitive::u64),
+    );
+    codegen.set_type_substitute(
+        parse_quote!(sp_arithmetic::per_things::PerU16),
+        parse_quote!(::core::primitive::u16),
+    );
+
     // Generate Rust code
-    let code = CodegenBuilder::new()
+    let code = codegen
         .generate(metadata)
         .expect("Failed to generate code from metadata");
 

--- a/lightning-tensor/src/app.rs
+++ b/lightning-tensor/src/app.rs
@@ -139,7 +139,12 @@ impl App {
     }
 
     /// Connect to the Bittensor network
-    pub async fn connect(&mut self, wallet_name: &str, hotkey_name: &str, netuid: u16) -> Result<(), AppError> {
+    pub async fn connect(
+        &mut self,
+        wallet_name: &str,
+        hotkey_name: &str,
+        netuid: u16,
+    ) -> Result<(), AppError> {
         let config = BittensorConfig::local(wallet_name, hotkey_name, netuid);
         let service = Service::new(config).await?;
         self.subtensor = Some(service);

--- a/lightning-tensor/src/ui/subnets.rs
+++ b/lightning-tensor/src/ui/subnets.rs
@@ -28,9 +28,7 @@ pub async fn draw<'a>(f: &mut Frame<'a>, app: &mut App, area: ratatui::layout::R
         .map(|subnet| {
             ListItem::new(Line::from(format!(
                 "Subnet {}: {} neurons (max {})",
-                subnet.netuid,
-                subnet.n,
-                subnet.max_n
+                subnet.netuid, subnet.n, subnet.max_n
             )))
         })
         .collect();

--- a/lightning-tensor/src/wallet_compat.rs
+++ b/lightning-tensor/src/wallet_compat.rs
@@ -55,20 +55,24 @@ impl Wallet {
     }
 
     /// Create a new wallet with a generated keypair
-    pub fn create_new_wallet(&mut self, _word_count: u32, _password: &str) -> Result<(), WalletError> {
+    pub fn create_new_wallet(
+        &mut self,
+        _word_count: u32,
+        _password: &str,
+    ) -> Result<(), WalletError> {
         // Generate a random keypair (always 12 words for simplicity)
         let (pair, phrase, _) = Pair::generate_with_phrase(None);
-        
+
         self.keypair = Some(pair);
-        
+
         // Save mnemonic to wallet directory
         let wallet_dir = self.path.join(&self.name);
         std::fs::create_dir_all(&wallet_dir)?;
-        
+
         // Note: In production, this should be encrypted with the password
         let mnemonic_path = wallet_dir.join("mnemonic.txt");
         std::fs::write(mnemonic_path, phrase)?;
-        
+
         Ok(())
     }
 
@@ -99,11 +103,16 @@ impl Wallet {
     }
 
     /// Verify a signature
-    pub fn verify(&self, message: &[u8], signature: &[u8], _password: &str) -> Result<bool, WalletError> {
+    pub fn verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        _password: &str,
+    ) -> Result<bool, WalletError> {
         let sig: Signature = signature
             .try_into()
             .map_err(|_| WalletError::KeypairError("Invalid signature length".to_string()))?;
-        
+
         match &self.keypair {
             Some(pair) => Ok(Pair::verify(&sig, message, &pair.public())),
             None => Err(WalletError::NotFound("No keypair loaded".to_string())),
@@ -111,7 +120,11 @@ impl Wallet {
     }
 
     /// Change the wallet password (stub)
-    pub async fn change_password(&mut self, _old_password: &str, _new_password: &str) -> Result<(), WalletError> {
+    pub async fn change_password(
+        &mut self,
+        _old_password: &str,
+        _new_password: &str,
+    ) -> Result<(), WalletError> {
         // TODO: Implement actual password change with re-encryption
         Ok(())
     }
@@ -127,4 +140,3 @@ impl KeypairWrapper {
         Ok(self.0.sign(message))
     }
 }
-


### PR DESCRIPTION
Current Finney metadata now exposes `NetUid`, `TaoBalance`, `AlphaBalance`, and `PerU16` as wrapper types, while the public client API still uses `u16` and `u64`. This caused generated calls and storage bindings to fail compilation.

Configure Subxt code generation to substitute those SCALE-compatible wrappers with their underlying primitives. Metadata fetching, caching, and offline fallback behavior are unchanged.

Validated against both current live Finney metadata (337,180 bytes) and bundled offline metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and consistency of generated runtime bindings.
  * Preserved SCALE-compatible primitive representations for selected numeric types, supporting more reliable client interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->